### PR TITLE
added Docker and Docker Compose config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,11 @@
-FROM node:argon
+FROM ubuntu:xenial
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y ffmpeg nodejs npm dstat 
+RUN ln -s /usr/bin/nodejs /usr/bin/node && mkdir /opt/shinobi
+WORKDIR /opt/shinobi
+ADD . .
+RUN npm install \
+    && chmod +x ./docker-entrypoint.sh
+ENTRYPOINT ./docker-entrypoint.sh
 
-# Create app directory
-RUN mkdir -p /home/shinobi
-WORKDIR /home/shinobi
-
-# Install app dependencies
-COPY package.json /home/shinobi/
-RUN npm install
-
-# Bundle app source
-COPY . /home/shinobi
-
-EXPOSE 80
-CMD [ "npm", "start" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: '2'
+services:
+   shinobi-db:
+     image: mysql:5.7
+     container_name: shinobi-db
+     env_file: ./docker.env
+     volumes:
+       - shinobi-db:/var/lib/mysql
+       - ./sql/framework.sql:/docker-entrypoint-initdb.d/framework.sql 
+       - ./sql/default_data.sql:/docker-entrypoint-initdb.d/zz_default_data.sql
+     restart: always
+
+   shinobi:
+     container_name: shinobi
+     build: 
+       context: .
+     env_file: ./docker.env
+     depends_on: 
+       - shinobi-db
+     restart: always
+     ports:
+       - "8080:8080"
+volumes:
+    shinobi-db:
+

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+SHIN_BIN_DIR=/opt/shinobi
+source $SHIN_BIN_DIR/docker.env
+#sed -i 's/server.listen(80)/server.listen(8080)/g' $SHIN_BIN_DIR/camera.js
+#sed -i 's/{"host":"127.0.0.1","user":"root","password":"","database":"ccio"}/{"host":"shinobi-db","user":"'${MYSQL_USER}'","'${MYSQL_PASSWORD}'":"","database":"ccio"}/g' $SHIN_BIN_DIR/conf.json
+
+sed -i 's/"port": 80/"port": 8080/g' $SHIN_BIN_DIR/conf.json
+sed -i 's/"host": "127.0.0.1"/"host": "shinobi-db"/g' $SHIN_BIN_DIR/conf.json
+sed -i 's/"user": "majesticflame"/"user": "'${MYSQL_USER}'"/g' $SHIN_BIN_DIR/conf.json
+sed -i 's/"password": ""/"password": "'${MYSQL_PASSWORD}'"/g' $SHIN_BIN_DIR/conf.json
+
+
+/usr/bin/nodejs camera.js

--- a/docker.env
+++ b/docker.env
@@ -1,0 +1,5 @@
+MYSQL_ROOT_PASSWORD=Ea7too4Aizaich#
+#harcoded
+MYSQL_DATABASE=ccio
+MYSQL_USER=shinobi
+MYSQL_PASSWORD=vuTh4eshoaqu9i


### PR DESCRIPTION
run "docker-compose build" followed by "docker-compose up".
go to http://hostname:8080 
The original port 80 forces the container to run in privileged mode which is undesirable from a security standpoint. 
Instead, use a Reverse Proxy like haproxy, nginx or apache on the host system or somewhere else for public exposure on port 80 or 443.
the Dockerfile can be used with a non containerized mysql installation running somewhere else with minor adjustments. 
Just setup the database manually, remove all but the first sed statements from dockerfile-entrypoint.sh, adjust conf.json manually and run "docker build . -t shinobi"