### PR TITLE
Docker improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,5 @@ RUN npm install
 RUN npm install pm2 -g
 RUN chmod +x ./docker-entrypoint.sh
 VOLUME ["/opt/shinobi/videos", "/opt/shinobi/conf"]
-EXPOSE 8083
-EXPOSE 3314
+EXPOSE 8080
 ENTRYPOINT ./docker-entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,7 @@ FROM ubuntu:xenial
 RUN apt update \
     && apt upgrade -y \
     && apt install -y ffmpeg nodejs npm libav-tools wget --no-install-recommends
-RUN echo 'mysql-server mysql-server/root_password password night' | debconf-set-selections
-RUN echo 'mysql-server mysql-server/root_password_again password night' | debconf-set-selections
-RUN apt -y install mysql-server --no-install-recommends
-RUN sed -ie "s/^bind-address\s*=\s*127\.0\.0\.1$/#bind-address = 127.0.0.1/" /etc/mysql/mysql.conf.d/mysqld.cnf
-RUN sed -ie "s/^port\s*=\s*3306$/port = 3314/" /etc/mysql/mysql.conf.d/mysqld.cnf
+RUN apt -y install mysql-client --no-install-recommends
 
 RUN ln -s /usr/bin/nodejs /usr/bin/node
 RUN mkdir /opt/shinobi
@@ -19,7 +15,7 @@ WORKDIR /opt/shinobi
 RUN npm install
 RUN npm install pm2 -g
 RUN chmod +x ./docker-entrypoint.sh
-VOLUME ["/var/log/mysql/","/opt/shinobi/videos"]
+VOLUME ["/opt/shinobi/videos", "/opt/shinobi/conf"]
 EXPOSE 8083
 EXPOSE 3314
 ENTRYPOINT ./docker-entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ COPY . /opt/shinobi
 WORKDIR /opt/shinobi
 
 ENV MYSQL_HOST="shinobi-db" \
+    MYSQL_DATABASE="shinobi" \
     MYSQL_ROOT_USER="root" \
     MYSQL_ROOT_PASSWORD="rootpass" \
     MYSQL_USER="ccio" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,11 @@ FROM ubuntu:xenial
 RUN apt update && apt install -y \
     ffmpeg nodejs npm libav-tools wget \
     mysql-client --no-install-recommends \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && ln -s /usr/bin/nodejs /usr/bin/node
 
-RUN ln -s /usr/bin/nodejs /usr/bin/node && mkdir /opt/shinobi
 COPY . /opt/shinobi
-RUN cp /opt/shinobi/conf.sample.json /opt/shinobi/conf.json && cp /opt/shinobi/super.sample.json /opt/shinobi/super.json \
-    && chmod -R 755 /opt/shinobi
+RUN cp /opt/shinobi/conf.sample.json /opt/shinobi/conf.json && cp /opt/shinobi/super.sample.json /opt/shinobi/super.json
 #RUN cp /opt/shinobi/plugins/motion/conf.sample.json /opt/shinobi/plugins/motion/conf.json
 WORKDIR /opt/shinobi
 RUN npm install && npm install pm2 -g && chmod +x ./docker-entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,16 @@
 FROM ubuntu:xenial
-RUN apt update \
-    && apt upgrade -y \
-    && apt install -y ffmpeg nodejs npm libav-tools wget --no-install-recommends
-RUN apt -y install mysql-client --no-install-recommends
+RUN apt update && apt install -y \
+    ffmpeg nodejs npm libav-tools wget \
+    mysql-client --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN ln -s /usr/bin/nodejs /usr/bin/node
-RUN mkdir /opt/shinobi
+RUN ln -s /usr/bin/nodejs /usr/bin/node && mkdir /opt/shinobi
 COPY . /opt/shinobi
-RUN cp /opt/shinobi/conf.sample.json /opt/shinobi/conf.json
-RUN cp /opt/shinobi/super.sample.json /opt/shinobi/super.json
+RUN cp /opt/shinobi/conf.sample.json /opt/shinobi/conf.json && cp /opt/shinobi/super.sample.json /opt/shinobi/super.json \
+    && chmod -R 755 /opt/shinobi
 #RUN cp /opt/shinobi/plugins/motion/conf.sample.json /opt/shinobi/plugins/motion/conf.json
-RUN chmod -R 755 /opt/shinobi
 WORKDIR /opt/shinobi
-RUN npm install
-RUN npm install pm2 -g
-RUN chmod +x ./docker-entrypoint.sh
+RUN npm install && npm install pm2 -g && chmod +x ./docker-entrypoint.sh
 VOLUME ["/opt/shinobi/videos"]
 EXPOSE 8080
 ENTRYPOINT ./docker-entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,6 @@ WORKDIR /opt/shinobi
 RUN npm install
 RUN npm install pm2 -g
 RUN chmod +x ./docker-entrypoint.sh
-VOLUME ["/opt/shinobi/videos", "/opt/shinobi/conf"]
+VOLUME ["/opt/shinobi/videos"]
 EXPOSE 8080
 ENTRYPOINT ./docker-entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,13 @@
 FROM ubuntu:xenial
 COPY . /opt/shinobi
 WORKDIR /opt/shinobi
+
+ENV MYSQL_HOST="shinobi-db" \
+    MYSQL_ROOT_USER="root" \
+    MYSQL_ROOT_PASSWORD="rootpass" \
+    MYSQL_USER="ccio" \
+    MYSQL_PASSWORD="shinobi"
+
 RUN apt update \
     && apt install --no-install-recommends -y ffmpeg nodejs npm libav-tools \
     wget mysql-client \
@@ -12,6 +19,7 @@ RUN apt update \
     && npm install pm2 -g \
     && chmod +x ./docker-entrypoint.sh
     # && cp /opt/shinobi/plugins/motion/conf.sample.json /opt/shinobi/plugins/motion/conf.json
+
 VOLUME ["/opt/shinobi/videos"]
 EXPOSE 8080
 ENTRYPOINT ./docker-entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,17 @@
 FROM ubuntu:xenial
-RUN apt update && apt install -y \
-    ffmpeg nodejs npm libav-tools wget \
-    mysql-client --no-install-recommends \
-    && rm -rf /var/lib/apt/lists/* \
-    && ln -s /usr/bin/nodejs /usr/bin/node
-
 COPY . /opt/shinobi
-RUN cp /opt/shinobi/conf.sample.json /opt/shinobi/conf.json && cp /opt/shinobi/super.sample.json /opt/shinobi/super.json
-#RUN cp /opt/shinobi/plugins/motion/conf.sample.json /opt/shinobi/plugins/motion/conf.json
 WORKDIR /opt/shinobi
-RUN npm install && npm install pm2 -g && chmod +x ./docker-entrypoint.sh
+RUN apt update \
+    && apt install --no-install-recommends -y ffmpeg nodejs npm libav-tools \
+    wget mysql-client \
+    && rm -rf /var/lib/apt/lists/* \
+    && ln -s /usr/bin/nodejs /usr/bin/node \
+    && cp /opt/shinobi/conf.sample.json /opt/shinobi/conf.json \
+    && cp /opt/shinobi/super.sample.json /opt/shinobi/super.json \
+    && npm install \
+    && npm install pm2 -g \
+    && chmod +x ./docker-entrypoint.sh
+    # && cp /opt/shinobi/plugins/motion/conf.sample.json /opt/shinobi/plugins/motion/conf.json
 VOLUME ["/opt/shinobi/videos"]
 EXPOSE 8080
 ENTRYPOINT ./docker-entrypoint.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,22 +1,22 @@
 version: '2'
 services:
-   shinobi:
-     container_name: shinobi
-     build: 
-       context: .
-     depends_on: 
-       - mysql
-     links:
-       - mysql:mysql
-     restart: always
-     environment:
-       - MYSQL_USER=shinobi
-       - MYSQL_DATABASE=cctv
-       - MYSQL_PASSWORD=shinobi_pass
-       - MYSQL_ROOT_PASSWORD=rootpass
-     ports:
-       - "8080:8080"
-   mysql:
-     image: mysql:latest
-     environment:
-       - MYSQL_ROOT_PASSWORD=rootpass
+  shinobi:
+    container_name: shinobi
+    build:
+      context: .
+    depends_on:
+      - mysql
+    restart: always
+    environment:
+      - MYSQL_HOST=shinobi-db
+      - MYSQL_USER=shinobi
+      - MYSQL_DATABASE=cctv
+      - MYSQL_PASSWORD=shinobi_pass
+      - MYSQL_ROOT_PASSWORD=rootpass
+    ports:
+      - "8080:8080"
+  mysql:
+    image: mysql:latest
+    container_name: shinobi-db
+    environment:
+     - MYSQL_ROOT_PASSWORD=rootpass

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,14 +9,17 @@ services:
     restart: always
     environment:
       - MYSQL_HOST=shinobi-db
+      - MYSQL_DATABASE=shinobi
       - MYSQL_USER=shinobi
-      - MYSQL_DATABASE=cctv
       - MYSQL_PASSWORD=shinobi_pass
       - MYSQL_ROOT_PASSWORD=rootpass
     ports:
-      - "8080:8080"
+      - "8088:8080"
   mysql:
-    image: mysql:latest
+    image: mysql:8
     container_name: shinobi-db
     environment:
-     - MYSQL_ROOT_PASSWORD=rootpass
+      - MYSQL_DATABASE=shinobi
+      - MYSQL_ROOT_PASSWORD=rootpass
+      - MYSQL_USER=shinobi
+      - MYSQL_PASSWORD=shinobi_pass

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,9 +4,19 @@ services:
      container_name: shinobi
      build: 
        context: .
-     env_file: ./docker.env
      depends_on: 
-       - shinobi-db
+       - mysql
+     links:
+       - mysql:mysql
      restart: always
+     environment:
+       - MYSQL_USER=shinobi
+       - MYSQL_DATABASE=cctv
+       - MYSQL_PASSWORD=shinobi_pass
+       - MYSQL_ROOT_PASSWORD=rootpass
      ports:
        - "8080:8080"
+   mysql:
+     image: mysql:latest
+     environment:
+       - MYSQL_ROOT_PASSWORD=rootpass

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - MYSQL_PASSWORD=shinobi_pass
       - MYSQL_ROOT_PASSWORD=rootpass
     ports:
-      - "8088:8080"
+      - "8080:8080"
   mysql:
     image: mysql:8
     container_name: shinobi-db

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,37 +4,20 @@ cd /opt/shinobi
 
 if [ ! -e "/opt/shinobi/installed.txt" ]; then
 #install stuff if not installed
-    touch /opt/shinobi/installed.txt
     my_mysql="/usr/bin/mysql -u root -p${MYSQL_ROOT_PASSWORD} -h mysql"
     /usr/bin/mysql -u root -p${MYSQL_ROOT_PASSWORD} -h mysql -e "CREATE DATABASE IF NOT EXISTS \`$MYSQL_DATABASE\` ;"
     /usr/bin/mysql -u root -p${MYSQL_ROOT_PASSWORD} -h mysql -e "CREATE USER '$MYSQL_USER'@'%' IDENTIFIED BY '$MYSQL_PASSWORD' ;"
     /usr/bin/mysql -u root -p${MYSQL_ROOT_PASSWORD} -h mysql -e "GRANT ALL ON $MYSQL_DATABASE.* TO '$MYSQL_USER'@'%';"
     /usr/bin/mysql -u root -p${MYSQL_ROOT_PASSWORD} -h mysql -e 'FLUSH PRIVILEGES ;'
     #mysql -u root -pnight < /opt/shinobi/sql/user.sql || true
-    /usr/bin/mysql -u root -p${MYSQL_ROOT_PASSWORD} -h mysql --database $MYSQL_DATABASE < /opt/shinobi/sql/framework.sql || true
-    /usr/bin/mysql -u root -p${MYSQL_ROOT_PASSWORD} -h mysql --database $MYSQL_DATABASE < /opt/shinobi/sql/default_data.sql || true
+    /usr/bin/mysql -u root -p${MYSQL_ROOT_PASSWORD} -h mysql --database $MYSQL_DATABASE < /opt/shinobi/sql/framework.sql
+    /usr/bin/mysql -u root -p${MYSQL_ROOT_PASSWORD} -h mysql --database $MYSQL_DATABASE < /opt/shinobi/sql/default_data.sql
     sed -i 's/"user": "majesticflame"/"user": "'"${MYSQL_USER}"'"/g' $SHIN_BIN_DIR/conf.json
     sed -i 's/"password": ""/"password": "'"${MYSQL_PASSWORD}"'"/g' $SHIN_BIN_DIR/conf.json
     sed -i 's/"host": "127.0.0.1"/"host": "mysql"/g' $SHIN_BIN_DIR/conf.json
     sed -i 's/"database": "ccio"/"database": "'"${MYSQL_DATABASE}"'"/g' $SHIN_BIN_DIR/conf.json
-    sed -i 's/"port": 8080/"port": 8083/g' $SHIN_BIN_DIR/conf.json
-    sed -i 's/"port":8080/"port":8083/g' $SHIN_BIN_DIR/plugins/motion/conf.json
     npm cache clean -f && npm install -g n && n stable
-else
-#update if already installed
-    wget https://github.com/moeiscool/Shinobi/tarball/master
-    mkdir master_temp
-    tar -xzf master -C master_temp --strip-components=1
-    rm -rf camera.js web UPDATE.sh package.json cron.js
-    mv master_temp/UPDATE.sh UPDATE.sh
-    chmod +x UPDATE.sh
-    mv master_temp/web web
-    mv master_temp/package.json package.json
-    mv master_temp/camera.js camera.js
-    mv master_temp/cron.js cron.js
-    mv master_temp/plugins/motion/shinobi-motion.js plugins/motion/shinobi-motion.js
-    npm install
-    rm -rf master master_temp
+    touch /opt/shinobi/installed.txt
 fi
 
 pm2 start /opt/shinobi/cron.js

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
+
 SHIN_BIN_DIR=/opt/shinobi
-MYSQL_USER="${MYSQL_USER:-ccio}"
+MYSQL_HOST="${MYSQL_HOST:-shinobi-db}"
 MYSQL_ROOT_USER="${MYSQL_ROOT_USER:-root}"
-MYSQL_HOST="${MYSQL_HOST:-mysql}"
-MYSQL_PASSWORD="${MYSQL_PASSWORD:-testpass}"
-cd /opt/shinobi
+MYSQL_ROOT_PASSWORD="${MYSQL_ROOT_PASSWORD:-rootpass}"
+MYSQL_USER="${MYSQL_USER:-ccio}"
+MYSQL_PASSWORD="${MYSQL_PASSWORD:-shinobi}"
+
+cd "$SHIN_BIN_DIR" || exit 9
 tables_check="select count(*) from information_schema.tables where table_schema='API' and table_name='${MYSQL_DATABASE}';"
 tables_num=$(/usr/bin/mysql -N -s -u ${MYSQL_ROOT_USER} -p${MYSQL_ROOT_PASSWORD} -h ${MYSQL_HOST} -e "${tables_check}")
 echo $tables_num

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,25 +1,28 @@
 #!/bin/bash
 SHIN_BIN_DIR=/opt/shinobi
+MYSQL_USER="${MYSQL_USER:-ccio}"
 MYSQL_ROOT_USER="${MYSQL_ROOT_USER:-root}"
 MYSQL_HOST="${MYSQL_HOST:-mysql}"
+MYSQL_PASSWORD="${MYSQL_PASSWORD:-testpass}"
 cd /opt/shinobi
+tables_check="select count(*) from information_schema.tables where table_schema='API' and table_name='${MYSQL_DATABASE}';"
+tables_num=$(/usr/bin/mysql -N -s -u ${MYSQL_ROOT_USER} -p${MYSQL_ROOT_PASSWORD} -h ${MYSQL_HOST} -e "${tables_check}")
+echo $tables_num
 
-if [ ! -e "/opt/shinobi/installed.txt" ]; then
-#install stuff if not installed
-    my_mysql="/usr/bin/mysql -u ${MYSQL_ROOT_USER} -p${MYSQL_ROOT_PASSWORD} -h ${MYSQL_HOST}"
+if [ "${tables_num}" -eq "0" ]; then
+     #install stuff if not installed
     /usr/bin/mysql -u ${MYSQL_ROOT_USER} -p${MYSQL_ROOT_PASSWORD} -h ${MYSQL_HOST} -e "CREATE DATABASE IF NOT EXISTS \`$MYSQL_DATABASE\` ;"
-    /usr/bin/mysql -u ${MYSQL_ROOT_USER} -p${MYSQL_ROOT_PASSWORD} -h ${MYSQL_HOST} -e "CREATE USER '$MYSQL_USER'@'%' IDENTIFIED BY '$MYSQL_PASSWORD' ;"
+    /usr/bin/mysql -u ${MYSQL_ROOT_USER} -p${MYSQL_ROOT_PASSWORD} -h ${MYSQL_HOST} -e "CREATE USER '$MYSQL_USER'@'%' IDENTIFIED BY '$MYSQL_PASSWORD';"
     /usr/bin/mysql -u ${MYSQL_ROOT_USER} -p${MYSQL_ROOT_PASSWORD} -h ${MYSQL_HOST} -e "GRANT ALL ON $MYSQL_DATABASE.* TO '$MYSQL_USER'@'%';"
-    /usr/bin/mysql -u ${MYSQL_ROOT_USER} -p${MYSQL_ROOT_PASSWORD} -h ${MYSQL_HOST} -e 'FLUSH PRIVILEGES ;'
+    /usr/bin/mysql -u ${MYSQL_ROOT_USER} -p${MYSQL_ROOT_PASSWORD} -h ${MYSQL_HOST} -e 'FLUSH PRIVILEGES;'
     #mysql -u ${MYSQL_ROOT_USER} -pnight < /opt/shinobi/sql/user.sql || true
     /usr/bin/mysql -u ${MYSQL_ROOT_USER} -p${MYSQL_ROOT_PASSWORD} -h ${MYSQL_HOST} --database $MYSQL_DATABASE < /opt/shinobi/sql/framework.sql
     /usr/bin/mysql -u ${MYSQL_ROOT_USER} -p${MYSQL_ROOT_PASSWORD} -h ${MYSQL_HOST} --database $MYSQL_DATABASE < /opt/shinobi/sql/default_data.sql
     sed -i 's/"user": "majesticflame"/"user": "'"${MYSQL_USER}"'"/g' $SHIN_BIN_DIR/conf.json
     sed -i 's/"password": ""/"password": "'"${MYSQL_PASSWORD}"'"/g' $SHIN_BIN_DIR/conf.json
-    sed -i 's/"host": "127.0.0.1"/"host": "mysql"/g' $SHIN_BIN_DIR/conf.json
+    sed -i 's/"host": "127.0.0.1"/"host": "'"${MYSQL_HOST}"'"/g' $SHIN_BIN_DIR/conf.json
     sed -i 's/"database": "ccio"/"database": "'"${MYSQL_DATABASE}"'"/g' $SHIN_BIN_DIR/conf.json
     npm cache clean -f && npm install -g n && n stable
-    touch /opt/shinobi/installed.txt
 fi
 
 pm2 start /opt/shinobi/cron.js

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,17 +1,19 @@
 #!/bin/bash
 SHIN_BIN_DIR=/opt/shinobi
+MYSQL_ROOT_USER="${MYSQL_ROOT_USER:-root}"
+MYSQL_HOST="${MYSQL_HOST:-mysql}"
 cd /opt/shinobi
 
 if [ ! -e "/opt/shinobi/installed.txt" ]; then
 #install stuff if not installed
-    my_mysql="/usr/bin/mysql -u root -p${MYSQL_ROOT_PASSWORD} -h mysql"
-    /usr/bin/mysql -u root -p${MYSQL_ROOT_PASSWORD} -h mysql -e "CREATE DATABASE IF NOT EXISTS \`$MYSQL_DATABASE\` ;"
-    /usr/bin/mysql -u root -p${MYSQL_ROOT_PASSWORD} -h mysql -e "CREATE USER '$MYSQL_USER'@'%' IDENTIFIED BY '$MYSQL_PASSWORD' ;"
-    /usr/bin/mysql -u root -p${MYSQL_ROOT_PASSWORD} -h mysql -e "GRANT ALL ON $MYSQL_DATABASE.* TO '$MYSQL_USER'@'%';"
-    /usr/bin/mysql -u root -p${MYSQL_ROOT_PASSWORD} -h mysql -e 'FLUSH PRIVILEGES ;'
-    #mysql -u root -pnight < /opt/shinobi/sql/user.sql || true
-    /usr/bin/mysql -u root -p${MYSQL_ROOT_PASSWORD} -h mysql --database $MYSQL_DATABASE < /opt/shinobi/sql/framework.sql
-    /usr/bin/mysql -u root -p${MYSQL_ROOT_PASSWORD} -h mysql --database $MYSQL_DATABASE < /opt/shinobi/sql/default_data.sql
+    my_mysql="/usr/bin/mysql -u ${MYSQL_ROOT_USER} -p${MYSQL_ROOT_PASSWORD} -h ${MYSQL_HOST}"
+    /usr/bin/mysql -u ${MYSQL_ROOT_USER} -p${MYSQL_ROOT_PASSWORD} -h ${MYSQL_HOST} -e "CREATE DATABASE IF NOT EXISTS \`$MYSQL_DATABASE\` ;"
+    /usr/bin/mysql -u ${MYSQL_ROOT_USER} -p${MYSQL_ROOT_PASSWORD} -h ${MYSQL_HOST} -e "CREATE USER '$MYSQL_USER'@'%' IDENTIFIED BY '$MYSQL_PASSWORD' ;"
+    /usr/bin/mysql -u ${MYSQL_ROOT_USER} -p${MYSQL_ROOT_PASSWORD} -h ${MYSQL_HOST} -e "GRANT ALL ON $MYSQL_DATABASE.* TO '$MYSQL_USER'@'%';"
+    /usr/bin/mysql -u ${MYSQL_ROOT_USER} -p${MYSQL_ROOT_PASSWORD} -h ${MYSQL_HOST} -e 'FLUSH PRIVILEGES ;'
+    #mysql -u ${MYSQL_ROOT_USER} -pnight < /opt/shinobi/sql/user.sql || true
+    /usr/bin/mysql -u ${MYSQL_ROOT_USER} -p${MYSQL_ROOT_PASSWORD} -h ${MYSQL_HOST} --database $MYSQL_DATABASE < /opt/shinobi/sql/framework.sql
+    /usr/bin/mysql -u ${MYSQL_ROOT_USER} -p${MYSQL_ROOT_PASSWORD} -h ${MYSQL_HOST} --database $MYSQL_DATABASE < /opt/shinobi/sql/default_data.sql
     sed -i 's/"user": "majesticflame"/"user": "'"${MYSQL_USER}"'"/g' $SHIN_BIN_DIR/conf.json
     sed -i 's/"password": ""/"password": "'"${MYSQL_PASSWORD}"'"/g' $SHIN_BIN_DIR/conf.json
     sed -i 's/"host": "127.0.0.1"/"host": "mysql"/g' $SHIN_BIN_DIR/conf.json

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,33 +2,45 @@
 
 SHIN_BIN_DIR=/opt/shinobi
 MYSQL_HOST="${MYSQL_HOST:-shinobi-db}"
+MYSQL_DATABASE="${MYSQL_DATABASE:-shinobi}"
 MYSQL_ROOT_USER="${MYSQL_ROOT_USER:-root}"
 MYSQL_ROOT_PASSWORD="${MYSQL_ROOT_PASSWORD:-rootpass}"
 MYSQL_USER="${MYSQL_USER:-ccio}"
 MYSQL_PASSWORD="${MYSQL_PASSWORD:-shinobi}"
 
 cd "$SHIN_BIN_DIR" || exit 9
-tables_check="select count(*) from information_schema.tables where table_schema='API' and table_name='${MYSQL_DATABASE}';"
-tables_num=$(/usr/bin/mysql -N -s -u ${MYSQL_ROOT_USER} -p${MYSQL_ROOT_PASSWORD} -h ${MYSQL_HOST} -e "${tables_check}")
-echo $tables_num
 
-if [ "${tables_num}" -eq "0" ]; then
-     #install stuff if not installed
-    /usr/bin/mysql -u ${MYSQL_ROOT_USER} -p${MYSQL_ROOT_PASSWORD} -h ${MYSQL_HOST} -e "CREATE DATABASE IF NOT EXISTS \`$MYSQL_DATABASE\` ;"
-    /usr/bin/mysql -u ${MYSQL_ROOT_USER} -p${MYSQL_ROOT_PASSWORD} -h ${MYSQL_HOST} -e "CREATE USER '$MYSQL_USER'@'%' IDENTIFIED BY '$MYSQL_PASSWORD';"
-    /usr/bin/mysql -u ${MYSQL_ROOT_USER} -p${MYSQL_ROOT_PASSWORD} -h ${MYSQL_HOST} -e "GRANT ALL ON $MYSQL_DATABASE.* TO '$MYSQL_USER'@'%';"
-    /usr/bin/mysql -u ${MYSQL_ROOT_USER} -p${MYSQL_ROOT_PASSWORD} -h ${MYSQL_HOST} -e 'FLUSH PRIVILEGES;'
-    #mysql -u ${MYSQL_ROOT_USER} -pnight < /opt/shinobi/sql/user.sql || true
-    /usr/bin/mysql -u ${MYSQL_ROOT_USER} -p${MYSQL_ROOT_PASSWORD} -h ${MYSQL_HOST} --database $MYSQL_DATABASE < /opt/shinobi/sql/framework.sql
-    /usr/bin/mysql -u ${MYSQL_ROOT_USER} -p${MYSQL_ROOT_PASSWORD} -h ${MYSQL_HOST} --database $MYSQL_DATABASE < /opt/shinobi/sql/default_data.sql
-    sed -i 's/"user": "majesticflame"/"user": "'"${MYSQL_USER}"'"/g' $SHIN_BIN_DIR/conf.json
-    sed -i 's/"password": ""/"password": "'"${MYSQL_PASSWORD}"'"/g' $SHIN_BIN_DIR/conf.json
-    sed -i 's/"host": "127.0.0.1"/"host": "'"${MYSQL_HOST}"'"/g' $SHIN_BIN_DIR/conf.json
-    sed -i 's/"database": "ccio"/"database": "'"${MYSQL_DATABASE}"'"/g' $SHIN_BIN_DIR/conf.json
+check_port() {
+    timeout 3 bash -c "</dev/tcp/$1/$2" 2>/dev/null
+}
+
+_mysql() {
+    mysql -u "${MYSQL_ROOT_USER}" -p"${MYSQL_ROOT_PASSWORD}" -h "${MYSQL_HOST}" $@
+}
+
+echo -n "Waiting for MYSQL server..."
+while ! check_port "$MYSQL_HOST" 3306
+do
+    :
+done
+echo 'Done!'
+
+tables_check="select count(*) from information_schema.tables where table_schema='API' and table_name='${MYSQL_DATABASE}';"
+tables_num=$(mysql -N -s -u "${MYSQL_ROOT_USER}" -p"${MYSQL_ROOT_PASSWORD}" -h "${MYSQL_HOST}" -e "${tables_check}")
+
+if [[ "${tables_num}" -eq "0" ]]
+then
+    # install stuff if not installed
+    _mysql --database "$MYSQL_DATABASE" < "${SHIN_BIN_DIR}/sql/framework.sql"
+    _mysql --database "$MYSQL_DATABASE" < "${SHIN_BIN_DIR}/sql/default_data.sql"
+    sed -i 's/"user": "majesticflame"/"user": "'"${MYSQL_USER}"'"/g' "$SHIN_BIN_DIR/conf.json"
+    sed -i 's/"password": ""/"password": "'"${MYSQL_PASSWORD}"'"/g' "$SHIN_BIN_DIR/conf.json"
+    sed -i 's/"host": "127.0.0.1"/"host": "'"${MYSQL_HOST}"'"/g' "$SHIN_BIN_DIR/conf.json"
+    sed -i 's/"database": "ccio"/"database": "'"${MYSQL_DATABASE}"'"/g' "$SHIN_BIN_DIR/conf.json"
     npm cache clean -f && npm install -g n && n stable
 fi
 
-pm2 start /opt/shinobi/cron.js
-pm2 start /opt/shinobi/camera.js
-#pm2 start /opt/shinobi/plugins/motion/shinobi-motion.js
+pm2 start "${SHIN_BIN_DIR}/cron.js"
+pm2 start "${SHIN_BIN_DIR}/camera.js"
+# pm2 start "${SHIN_BIN_DIR}/plugins/motion/shinobi-motion.js"
 pm2 logs

--- a/sql/framework.sql
+++ b/sql/framework.sql
@@ -11,9 +11,6 @@
 /*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
 
 -- Dumping database structure for ccio
-CREATE DATABASE IF NOT EXISTS `ccio` /*!40100 DEFAULT CHARACTER SET utf8 */;
-USE `ccio`;
-
 
 -- Dumping structure for table ccio.API
 CREATE TABLE IF NOT EXISTS `API` (

--- a/sql/user.sql
+++ b/sql/user.sql
@@ -1,3 +1,4 @@
 CREATE USER 'majesticflame'@'127.0.0.1' IDENTIFIED BY '';
-GRANT ALL PRIVILEGES ON * . * TO 'majesticflame'@'127.0.0.1';
+CREATE DATABASE IF NOT EXISTS `ccio`;
+GRANT ALL PRIVILEGES ON ccio.* TO 'majesticflame'@'127.0.0.1';
 FLUSH PRIVILEGES;


### PR DESCRIPTION
This PR builds upon @simonoff changes (https://github.com/moeiscool/Shinobi/pull/143) and brings some minor extra changes regarding image size and docker-compose shenanigans.

The one big change this introduces is better docker-compose support and it fixes the persistence issue.
To start Shinobi a simple `docker-compose up` is enough.

Data persistence can be obtained by using standard Docker volumes.
[HERE](https://gist.github.com/pschmitt/52090e8a862d308d1d7f156665bf2520) is an example docker-compose file that does exactly that.

Related issues: 
- https://github.com/moeiscool/Shinobi/issues/125