### PR TITLE
Emergency

### DIFF
--- a/INSTALL/ubuntu.sh
+++ b/INSTALL/ubuntu.sh
@@ -37,9 +37,6 @@ npm install pm2 -g
 if [ ! -e "./conf.json" ]; then
     cp conf.sample.json conf.json
 fi
-if [ ! -e "./super.json" ]; then
-    cp super.sample.json super.json
-fi
 pm2 start camera.js
 pm2 start cron.js
 pm2 list


### PR DESCRIPTION
Users with large video counts (+1000) will experience horrors unimagined :( The problem was a calculator was not finished checking the videos on process start. The closer that starts deleting over max started to think it was time to delete before it was ready. Thus killing off many innocent video files :( This update makes it so that the close function runs at the very end of all calculations.