### PR TITLE
Optimize Dockerfile to use Docker cache.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,19 @@
 FROM mhart/alpine-node:8
 
 WORKDIR /opt/shinobi
+
+# Install package dependencies
 RUN apk add --update --no-cache ffmpeg python pkgconfig cairo-dev make g++ jpeg-dev
 
-COPY . /opt/shinobi
-
+# Install NodeJS dependencies
+COPY package.json /opt/shinobi
 RUN npm install && \
     npm install canvas
 
+# Copy code
+COPY . /opt/shinobi
+
 VOLUME ["/opt/shinobi/videos"]
+
 EXPOSE 8080
 ENTRYPOINT ["/opt/shinobi/docker-entrypoint.sh" ]


### PR DESCRIPTION
By copying only the `package.json` file first, and then doing the `npm install`, Docker doesn't invalidate the npm packages when other files are changed.

More info: http://bitjudo.com/blog/2014/03/13/building-efficient-dockerfiles-node-dot-js/