### PR TITLE
Recursive deleting can be dangerous

### DIFF
--- a/camera.js
+++ b/camera.js
@@ -923,11 +923,11 @@ s.file=function(x,e){
         break;
         case'delete':
             if(!e){return false;}
-            return exec('rm -rf '+e,{detached: true});
+            return exec('rm -f '+e,{detached: true});
         break;
         case'delete_files':
             if(!e.age_type){e.age_type='min'};if(!e.age){e.age='1'};
-            exec('find '+e.path+' -type f -c'+e.age_type+' +'+e.age+' -exec rm -rf {} +',{detached: true});
+            exec('find '+e.path+' -type f -c'+e.age_type+' +'+e.age+' -exec rm -f {} +',{detached: true});
         break;
     }
 }


### PR DESCRIPTION
On deleting files (videos) or SHM-Entries there is no need to use the -r option of "rm". It could be very dangerous, because in many setups Shinobi runs as root and could destroy in worst cast the whole file system of the host (e.g. in case of software bugs, where s.file("delete", "/") is called.